### PR TITLE
Add multi framework targets and NuGet metadata to ApiExceptionMiddleware

### DIFF
--- a/src/Df.ApiExceptionMiddleware/Df.ApiExceptionMiddleware/Df.ApiExceptionMiddleware.csproj
+++ b/src/Df.ApiExceptionMiddleware/Df.ApiExceptionMiddleware/Df.ApiExceptionMiddleware.csproj
@@ -1,25 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RepositoryUrl>https://github.com/DanskeFragtmaend/Public</RepositoryUrl>
-        <Description>Middleware to handle exceptions thrown in the pipeline</Description>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Df.ApiExceptionMiddleware</PackageId>
+        <Authors>Danske Fragtmænd A/S</Authors>
         <Copyright>Danske Fragtmænd A/S</Copyright>
+        <Description>Middleware to handle exceptions thrown in the pipeline</Description>
+        <RepositoryUrl>https://github.com/DanskeFragtmaend/Public</RepositoryUrl>
         <PackageTags>danske fragtmænd;api;exception;middleware;error;pipeline</PackageTags>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <DebugType>portable</DebugType>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>
+            $(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb
+        </AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.9" Condition="'$(TargetFramework)' == 'net9.0'" />
     </ItemGroup>
 
     <ItemGroup>
-      <None Include="..\readme.md">
-        <Link>readme.md</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
+        <None Include="..\readme.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>

--- a/src/Df.ApiExceptionMiddleware/TestApi/Program.cs
+++ b/src/Df.ApiExceptionMiddleware/TestApi/Program.cs
@@ -1,11 +1,20 @@
+using System.Reflection;
+using System.Xml;
 using Df.ApiExceptionMiddleware;
+using log4net;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
+builder.Logging.ClearProviders();
+builder.Logging.AddLog4Net("log4net.config");
+
+var log4NetConfiguration = new XmlDocument();
+log4NetConfiguration.Load(File.OpenRead("log4net.config"));
+var repo = LogManager.CreateRepository(Assembly.GetEntryAssembly(), typeof(log4net.Repository.Hierarchy.Hierarchy));
+log4net.Config.XmlConfigurator.Configure(repo, log4NetConfiguration["log4net"]);
 
 builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 

--- a/src/Df.ApiExceptionMiddleware/TestApi/TestApi.csproj
+++ b/src/Df.ApiExceptionMiddleware/TestApi/TestApi.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="8.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     </ItemGroup>
 

--- a/src/Df.ApiExceptionMiddleware/TestApi/log4net.config
+++ b/src/Df.ApiExceptionMiddleware/TestApi/log4net.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+  <appender name="RollingFile" type="log4net.Appender.RollingFileAppender">
+    <file value="F:\Public\ApiExceptionMiddleware.TestApi.txt" />
+    <appendToFile value="true" />
+    <rollingStyle value="Size" />
+    <maxSizeRollBackups value="10" />
+    <maximumFileSize value="10MB" />
+    <staticLogFileName value="true" />
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%-5p %d %-30.30c{1} - %m%n" />
+    </layout>
+  </appender>
+  <root>
+    <level value="ALL" />
+    <appender-ref ref="RollingFile" />
+  </root>
+</log4net>


### PR DESCRIPTION
Updates Df.ApiExceptionMiddleware to target net7.0, net8.0, and net9.0 with framework-specific dependencies. Adds NuGet package metadata including licensing, tags, and documentation.

Additionally, updates the TestApi to net9.0 and configures log4net logging to support better diagnostics during testing.
